### PR TITLE
soft tabbing done for both solo mode and challenge mode

### DIFF
--- a/app/components/ChallengeArena.js
+++ b/app/components/ChallengeArena.js
@@ -1,28 +1,34 @@
 var React = require('react');
 var io = require('socket.io-client');
 var socket = require('../sockets/socket-helper');
+var _ = require('lodash');
+
+var selfEditorOptions = {
+  theme: "ace/theme/solarized_light",
+  mode: "ace/mode/javascript",
+  blockScrolling: Infinity,
+  useSoftTabs: true,
+  tabSize: 2,
+  wrap: true
+};
+var challengerEditorOptions = _.create(selfEditorOptions, {
+  theme: "ace/theme/solarized_dark",
+  readOnly: true,
+  highlightActiveLine: false,
+  highlightGutterLine: false
+});
+
 var ChallengeArena = React.createClass({
   componentDidMount: function() {
     //setting up solo (player) editor
     var editor = ace.edit('editor');
-    editor.setTheme("ace/theme/solarized_light");
-    editor.session.setMode("ace/mode/javascript");
-    editor.getSession().setUseWrapMode(true);
-    editor.$blockScrolling = Infinity;
+    editor.setOptions(selfEditorOptions);
     this.props.arenaActions.storeEditor(editor);
 
     //setting up opponnent editor
     var editor2 = ace.edit('editor2');
-    editor2.$blockScrolling = Infinity;
-    editor2.getSession().setUseWrapMode(true);
-    editor2.setOptions({
-      readOnly: true,
-      highlightActiveLine: false,
-      highlightGutterLine: false
-    })
-    editor2.setTheme("ace/theme/solarized_dark")
+    editor2.setOptions(challengerEditorOptions);
     this.props.arenaActions.storeEditorOpponent(editor2);
-
 
     this.props.arena.socket.on('keypress', function(data){
       var array = data.split('');

--- a/app/components/SoloArena.js
+++ b/app/components/SoloArena.js
@@ -1,18 +1,24 @@
 var React = require('react');
 var io = require('socket.io-client');
 
-
 var ErrorList = require('./ErrorList');
 var socket = require('../sockets/socket-helper');
+
+var selfEditorOptions = {
+  // theme: "ace/theme/solarized_light",
+  theme: "ace/theme/monokai",
+  mode: "ace/mode/javascript",
+  blockScrolling: Infinity,
+  useSoftTabs: true,
+  tabSize: 2,
+  wrap: true
+};
 
 var SoloArena = React.createClass({
   componentDidMount: function(){
     var editor = ace.edit("editor");
-    editor.setTheme("ace/theme/monokai");
-    editor.getSession().setMode("ace/mode/javascript");
-    editor.$blockScrolling = Infinity
+    editor.setOptions(selfEditorOptions);
     this.props.arenaActions.storeEditor(editor);
-
   },
   componentDidUpdate: function(){
     this.props.arena.editorSolo.setValue(this.props.arena.content,1);


### PR DESCRIPTION
#### What's this PR do?

Enforced soft tabbing, and 2 space for tabbing
#### What are the important parts of the code?

challengeArena.js and soloArena.js
#### How should this be tested by the reviewer?
1. Run webpack, start nodemon server/server.js
2. Navigate to 127.0.0.1:3000 then got to practice mode and challenge mode
#### Is any other information necessary to understand this?
#### What are the relevant tickets? (Please add `closes`, `refs`, etc)
#### Screenshots (if appropriate)
