### PR TITLE
fixed cursor placement after rerender

### DIFF
--- a/app/reducers/arenaReducers.js
+++ b/app/reducers/arenaReducers.js
@@ -71,7 +71,7 @@ function arenaReducer (state, action){
       return _.extend({}, state, {
         content: '',
         status: '',
-        opponentStatus: "waiting for other player... when propmt appears, you may begin hacking. be ready.",
+        opponentStatus: "waiting for other player... when prompt appears, you may begin hacking. be ready.",
         submissionMessage: 'Nothing passing so far...(From initial arena reducer)',
         stdout: '',
         opponent_info: {}

--- a/app/sockets/socket-helper.js
+++ b/app/sockets/socket-helper.js
@@ -53,7 +53,9 @@ socket.on('eval', function(submissionMessage, challenge_id){
 });
 
 socket.on('won', function(data) {
+  var cursor = store.getState().arena.editorSolo.selection.getCursor();
   store.dispatch(arenaAction.lostChallenge(store.getState().arena.editorSolo.getSession().getValue()));
+  store.getState().arena.editorSolo.moveCursorTo(cursor.row, cursor.column);
 })
 
 module.exports = socket;


### PR DESCRIPTION
#### What's this PR do?

cursor placement is static even after rerender from losing challenge
#### What are the important parts of the code?

socket-helper.js
#### How should this be tested by the reviewer?

test challenge arena and observer cursor movement on losing player
#### Is any other information necessary to understand this?
#### What are the relevant tickets? (Please add `closes`, `refs`, etc)

closes #109, #107
#### Screenshots (if appropriate)
