### PR TITLE
content of opponent no longer clears

### DIFF
--- a/app/actions/arenaActions.js
+++ b/app/actions/arenaActions.js
@@ -44,9 +44,10 @@ var lostChallenge = function (payload) {
   };
 };
 
-var playerLeave = function(){
+var playerLeave = function(payload){
   return {
-    type: actions.PLAYER_LEAVE
+    type: actions.PLAYER_LEAVE,
+    payload: payload
   };
 };
 

--- a/app/reducers/arenaReducers.js
+++ b/app/reducers/arenaReducers.js
@@ -95,6 +95,7 @@ function arenaReducer (state, action){
       }
     case actions.PLAYER_LEAVE:
       return _.extend({}, state, {
+        content: action.payload,
         opponentStatus: 'The other player has left the room.',
         opponent_info: {}
       });

--- a/app/sockets/socket-helper.js
+++ b/app/sockets/socket-helper.js
@@ -35,7 +35,7 @@ socket.on('keypress', function (data) {
 
 
 socket.on('playerLeave', function (data) {
-  store.dispatch(arenaAction.playerLeave());
+  store.dispatch(arenaAction.playerLeave(store.getState().arena.editorSolo.getSession().getValue()));
 });
 
 socket.on('otherPlayer', function (data) {


### PR DESCRIPTION
#### What's this PR do?

-fixes bug where player leaving before submitting solutions clears the content
#### What are the important parts of the code?
- in arena-reducer + socket-helpers
#### How should this be tested by the reviewer?
- enter the arena on two sessions. type content in one, but do NOT submit. leave from the other session
#### Screenshots (if appropriate)
